### PR TITLE
Add openssl-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
 name = "gram"
 version = "0.1.0"
 dependencies = [
+ "openssl-sys",
  "reqwest",
  "serde",
  "structopt",
@@ -490,6 +491,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.6.1+1.1.1d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +508,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.10.4", features = [ "json" ] }
-serde = { version = "1.0.104", features = [ "derive" ] }
+openssl-sys = { version = "0.9.54", features = ["vendored"] }
+reqwest = { version = "0.10.4", features = ["json"] }
+serde = { version = "1.0.104", features = ["derive"] }
 tokio = { version = "0.2.13", features = ["macros"] }
 toml = "0.5.6"
 structopt = "0.3.11"


### PR DESCRIPTION
Adds openssl-sys as a dependency with the vendored feature enabled. 

This allows cross compilation with the musl target, giving us a statically linked binary.

```shell
$ cargo build --target x86_64-unknown-linux-musl --release
```